### PR TITLE
fixed an error caused by templates with different encodings

### DIFF
--- a/django_unused_templates.py
+++ b/django_unused_templates.py
@@ -58,7 +58,7 @@ def get_unused_templates(skip, fast, filename):
         if fast:
             lines = files_content
         else:
-            lines = fileinput.input(files)
+            lines = fileinput.input(files, openhook=fileinput.hook_encoded("utf-8"))
 
         for line in lines:
             if line.find(template) > 0:


### PR DESCRIPTION
was getting an error: `UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position []: character maps to <undefined>`

so I added the argument `openhook=fileinput.hook_encoded("utf-8")` to fix it... 